### PR TITLE
Feat/recipe like features

### DIFF
--- a/schema.gql
+++ b/schema.gql
@@ -322,6 +322,9 @@ type RecipeDto {
   """Is A Favorite Recipe"""
   isFavorite: Boolean
 
+  """Whether the current user has liked this recipe"""
+  isLiked: Boolean
+
   """Denormalized likes count"""
   likesCount: Int!
 

--- a/src/modules/recipe/dto/recipe.dto.ts
+++ b/src/modules/recipe/dto/recipe.dto.ts
@@ -38,6 +38,12 @@ export class RecipeDto {
   })
   hotScore?: number;
 
+  @Field(() => Boolean, {
+    description: 'Whether the current user has liked this recipe',
+    nullable: true,
+  })
+  isLiked?: boolean;
+
   @Field(() => UserDto, { description: 'Recipe Author Detail' })
   author: UserDto;
 

--- a/src/modules/recipe/entities/recipe-like.entity.ts
+++ b/src/modules/recipe/entities/recipe-like.entity.ts
@@ -1,0 +1,36 @@
+import { AbstractEntity } from 'src/database/database.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Recipe } from './recipe.entity';
+import { User } from '@module/user/entities/user.entity';
+
+@Entity({ name: 'recipe_likes' })
+@Index(['userId', 'recipeId'], { unique: true })
+export class RecipeLike extends AbstractEntity<RecipeLike> {
+  @Column({ name: 'user_id' })
+  userId: number;
+
+  @Column({ name: 'recipe_id' })
+  recipeId: number;
+
+  @CreateDateColumn({
+    name: 'created_at',
+    type: 'timestamp with time zone',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  createdAt: Date;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @ManyToOne(() => Recipe)
+  @JoinColumn({ name: 'recipe_id' })
+  recipe: Recipe;
+}

--- a/src/modules/recipe/recipe.module.ts
+++ b/src/modules/recipe/recipe.module.ts
@@ -6,6 +6,7 @@ import { Recipe } from './entities/recipe.entity';
 import { RecipeIngredient } from './entities/recipe-ingredient.entity';
 import { RecipeInstruction } from './entities/recipe-instruction.entity';
 import { RecipeMedia } from './entities/recipe-media.entity';
+import { RecipeLike } from './entities/recipe-like.entity';
 import { AuthModule } from '@module/auth/auth.module';
 import { RecipeRepository } from './recipe.repository';
 import { SearchServiceModule } from './grpc/search-service.module';
@@ -18,6 +19,7 @@ import { EngagementServiceModule } from '@module/user/grpc/engagement-service.mo
       RecipeIngredient,
       RecipeInstruction,
       RecipeMedia,
+      RecipeLike,
     ]),
     AuthModule,
     SearchServiceModule,

--- a/src/modules/recipe/recipe.repository.ts
+++ b/src/modules/recipe/recipe.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Recipe } from './entities/recipe.entity';
+import { RecipeLike } from './entities/recipe-like.entity';
 import { EntityManager, Repository } from 'typeorm';
 import { RecipeDto, RecipeInput } from './dto/recipe.dto';
 import { RecipeIngredient } from './entities/recipe-ingredient.entity';
@@ -19,6 +20,8 @@ export class RecipeRepository implements OnModuleInit {
   constructor(
     @InjectRepository(Recipe)
     private readonly repository: Repository<Recipe>,
+    @InjectRepository(RecipeLike)
+    private readonly recipeLikeRepository: Repository<RecipeLike>,
     private readonly entityManager: EntityManager,
     @Inject('SEARCH_SERVICE') private readonly searchClient: ClientGrpc,
   ) {}
@@ -538,5 +541,20 @@ export class RecipeRepository implements OnModuleInit {
         false,
       ];
     }
+  }
+
+  async checkIsLiked(recipeId: number, userId?: number): Promise<boolean> {
+    if (!userId) {
+      return false;
+    }
+
+    const like = await this.recipeLikeRepository.findOne({
+      where: {
+        recipeId,
+        userId,
+      },
+    });
+
+    return !!like;
   }
 }

--- a/src/modules/recipe/recipe.resolver.ts
+++ b/src/modules/recipe/recipe.resolver.ts
@@ -6,6 +6,7 @@ import { CurrentUser } from '@module/user/decorator/current-user.decorator';
 import { TokenPayload } from '@common/dto/tokenPayload.dto';
 import { UseGuards } from '@nestjs/common';
 import { JwtAuthGuard } from '@module/auth/guards/jwt-auth.guard';
+import { OptionalJwtAuthGuard } from '@module/auth/guards/optional-jwt-auth.guard';
 import { InputValidationPipe } from '@common/middleware/auth/input-validation.pipe';
 import {
   CreateRecipeSchema,
@@ -61,10 +62,12 @@ export class RecipeResolver {
   }
 
   @Query(() => RecipeDto, { name: 'recipeDetail' })
+  @UseGuards(OptionalJwtAuthGuard)
   async recipeDetail(
     @Args('id', { type: () => Int }) id: number,
+    @CurrentUser() user?: TokenPayload,
   ): Promise<RecipeDto> {
-    return this.recipeService.findOne(id);
+    return this.recipeService.findOne(id, user?.sub);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/modules/recipe/recipe.service.ts
+++ b/src/modules/recipe/recipe.service.ts
@@ -210,13 +210,16 @@ export class RecipeService implements OnModuleInit {
     }
   }
 
-  async findOne(id: number): Promise<RecipeDto> {
+  async findOne(id: number, userId?: number): Promise<RecipeDto> {
     try {
       const recipe = await this.recipeRepository.findById(id);
 
       if (!recipe) {
         throw new GraphQLError('Recipe not found.');
       }
+
+      // Check if user has liked this recipe
+      const isLiked = await this.recipeRepository.checkIsLiked(id, userId);
 
       const ingredients = recipe.ingredients.map((ingredient) => {
         const recipeIngredientDto: RecipeIngredientDto =
@@ -258,6 +261,7 @@ export class RecipeService implements OnModuleInit {
         instructions,
         image,
         author,
+        isLiked,
         createdAt: utcToAsiaJakarta(recipe.createdAt),
         updatedAt: utcToAsiaJakarta(recipe.updatedAt),
       };
@@ -448,6 +452,9 @@ export class RecipeService implements OnModuleInit {
         throw new GraphQLError('Recipe not found.');
       }
 
+      // Check if user has liked this recipe
+      const isLiked = await this.recipeRepository.checkIsLiked(id, userId);
+
       const ingredients = recipe.ingredients.map((ingredient) => {
         const recipeIngredientDto: RecipeIngredientDto =
           new RecipeIngredientDto({
@@ -488,6 +495,7 @@ export class RecipeService implements OnModuleInit {
         instructions,
         image,
         author,
+        isLiked,
         createdAt: utcToAsiaJakarta(recipe.createdAt),
         updatedAt: utcToAsiaJakarta(recipe.updatedAt),
       };


### PR DESCRIPTION
feat(recipe): add isLiked field to recipeDetail and myRecipeDetail queries

- Create RecipeLike entity for recipe_likes table with unique index on (user_id, recipe_id)
- Add isLiked field to RecipeDto (nullable boolean) for GraphQL schema
- Implement checkIsLiked method in RecipeRepository to query recipe_likes table
- Update findOne to accept optional userId and include isLiked status
- Update findOneMyRecipe to include isLiked status for authenticated user
- Use OptionalJwtAuthGuard on recipeDetail query to support both authenticated and unauthenticated access
- Pass userId from JWT token to service methods for like status check
- Return isLiked: false for unauthenticated users (no JWT token)
- Return isLiked: true/false for authenticated users based on recipe_likes table

Breaking changes: None
- recipeDetail remains publicly accessible
- myRecipeDetail still requires authentication
- New isLiked field is nullable, ensuring backward compatibility

Files modified:
- src/modules/recipe/entities/recipe-like.entity.ts (NEW)
- src/modules/recipe/dto/recipe.dto.ts
- src/modules/recipe/recipe.module.ts
- src/modules/recipe/recipe.repository.ts
- src/modules/recipe/recipe.service.ts
- src/modules/recipe/recipe.resolver.ts

Security notes:
- userId extracted from JWT token, not from GraphQL arguments
- OptionalJwtAuthGuard allows public access while extracting user context if available
- SQL query uses proper WHERE clause with userId and recipeId to prevent unauthorized access